### PR TITLE
Watch more files than just *.liquid

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,9 @@ function isChanged(file) {
 }
 
 var filterChanged = filter(isChanged);
+var paths = {
+	shopfiles: ['**/*.liquid', 'locales/*.json']
+};
 
 gulp.task('serve', function() {
   browserSync.init({
@@ -48,9 +51,9 @@ gulp.task('sass', function() {
     .pipe(browserSync.stream());
 });
 
-gulp.task('liquid', function() {
-  return gulp.src('**/*.liquid')
-    .pipe(watch('**/*.liquid'))
+gulp.task('shopfiles', function() {
+  return gulp.src(paths.shopfiles)
+    .pipe(watch(paths.shopfiles))
     .pipe(filterChanged)
     .pipe(shell([
       'theme upload <%= f(file.path) %>'
@@ -65,4 +68,4 @@ gulp.task('liquid', function() {
     .pipe(browserSync.stream());
 });
 
-gulp.task('default', ['serve', 'liquid']);
+gulp.task('default', ['serve', 'shopfiles']);


### PR DESCRIPTION
The original version of gulp.js only watched .liquid files, hence ignoring files such as locales/*.json. I modified the original `liquid` task to use the variable `shopfiles` that contains an array of file patterns to watch instead of taking the literal string `**/*.liquid` and renamed the task to `shopfiles`.

Please note: I'm new to gulp.js, so pull with caution and feel free to ignore ;)
